### PR TITLE
Fix #139: Correct allele ID found even when PRG alphabet is discontinuous

### DIFF
--- a/libgramtools/src/search/search.cpp
+++ b/libgramtools/src/search/search.cpp
@@ -308,8 +308,12 @@ SA_Interval gram::get_allele_marker_sa_interval(const Marker &site_marker_char,
     const auto start_sa_index = prg_info.fm_index.C[alphabet_rank];
 
     const auto next_boundary_marker = allele_marker_char + 1;
-    const auto max_char_in_alphabet = prg_info.fm_index.sigma - 1;
-    const bool next_boundary_marker_valid = next_boundary_marker <= max_char_in_alphabet;
+    // sigma: contains the size (=number of unique symbols) of the alphabet
+    const auto max_alphabet_char = prg_info.fm_index.comp2char[prg_info.fm_index.sigma - 1];
+
+    // The max_alphabet_char is one of {1, 2, 3, 4, <max allele marker>}
+    // next_boundary_marker is already > 4, therefore conditional simplifies to the following
+    const bool next_boundary_marker_valid = next_boundary_marker < max_alphabet_char;
 
     SA_Index end_sa_index;
     if (next_boundary_marker_valid) {
@@ -329,6 +333,7 @@ AlleleId gram::get_allele_id(const SA_Index &allele_marker_sa_index,
                              const PRG_Info &prg_info) {
     auto internal_allele_text_index = prg_info.fm_index[allele_marker_sa_index] - 1;
     auto allele_id = (AlleleId) prg_info.allele_mask[internal_allele_text_index];
+    assert(allele_id > 0);
     return allele_id;
 }
 

--- a/libgramtools/tests/test_search.cpp
+++ b/libgramtools/tests/test_search.cpp
@@ -364,6 +364,32 @@ TEST(Search, GivenBoundaryMarkerAndTwoAlleles_GetAlleleMarkerSaInterval) {
 
 
 /*
+PRG: 7g8c7g9t10a9
+i	F	BTW	text	SA	suffix
+0	0	9	7	    11	0
+1	1	10	3	    9	1 9 0
+2	2	8	8	    3	2 7 3 9 4 10 1 9 0
+3	3	7	2	    1	3 8 2 7 3 9 4 10 1 9 0
+4	3	7	7	    7	3 9 4 10 1 9 0
+5	4	9	3	    7	4 10 1 9 0
+6	7	0	9	    0	7 3 8 2 7 3 9 4 10 1 9 0
+7	7	2	4	    4	7 3 9 4 10 1 9 0
+8	8	3	10	    2	8 2 7 3 9 4 10 1 9 0
+9	9	1	1	    10	9 0
+10	9	3	9	    8	9 4 10 1 9 0
+11	10	4	0	    8	10 1 9 0
+*/
+TEST(Search, GivenPrgWithNonContiniousAlphabet_CorrectAlleleMarkerEndBoundary) {
+    auto prg_raw = "7g8c7g9t10a9";
+    auto prg_info = generate_prg_info(prg_raw);
+
+    auto result = get_allele_marker_sa_interval(7, prg_info);
+    SA_Interval expected = {8, 8};
+    EXPECT_EQ(result, expected);
+}
+
+
+/*
 PRG: gcgct5c6g6t5agtcct
 i	F	BWT	text	SA	suffix
 0	0	4	 3	    18	  0


### PR DESCRIPTION
This edge case is currently only found in tests.

This solution handles the edge case and makes gramtools more robust in the eventuality that a single PRG is analyzed in parts.